### PR TITLE
Handling too large inputs gracefully

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-"""Setup file for veezio backend"""
+"""Setup file for lz4 backend"""
 
 from setuptools import setup, find_packages, Extension
 
-VERSION = (0, 4, 0)
+VERSION = (0, 4, 1)
 
 setup(
     name='lz4',

--- a/src/lz4.c
+++ b/src/lz4.c
@@ -327,6 +327,10 @@ inline static int LZ4_NbCommonBytes (register U32 val)
 
 int LZ4_compressBound(int isize)
 {
+	static const int max_size = 2139095024;
+	if (isize < 0 || isize > max_size) {
+		return -1;
+	}
 	return (isize + (isize/255) + 16);
 }
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -2,4 +2,20 @@ import lz4
 import sys
 
 DATA = open("/dev/urandom", "rb").read(128 * 1024)  # Read 128kb
-sys.exit(DATA != lz4.loads(lz4.dumps(DATA)) and 1 or 0)
+if DATA != lz4.loads(lz4.dumps(DATA)):
+    sys.exit(1)
+
+# max size
+DATA = "x" * 2139095020
+if DATA != lz4.loads(lz4.dumps(DATA)):
+    sys.exit(1)
+
+# max size + 1
+DATA = DATA + "x"
+try:
+    lz4.dumps(DATA)
+    sys.exit(1)
+except ValueError:
+    pass
+
+sys.exit(0)


### PR DESCRIPTION
Currently, if the input is over 2 GB, lz4.compress may silently truncate the input, or if you get lucky, raise "SystemError: Negative size passed to PyString_FromStringAndSize". This pull request handles too large inputs and raises ValueError for too large inputs. Requires Python 2.5 or newer for Py_ssize_t support. Bumping version number to 0.4.1.
