### PR TITLE
Fix #6 Unable to compile under Windows

### DIFF
--- a/src/python-lz4.c
+++ b/src/python-lz4.c
@@ -202,10 +202,11 @@ initlz4(void)
 #else
     PyObject *module = Py_InitModule("lz4", Lz4Methods);
 #endif
+    struct module_state *st = NULL;
 
     if (module == NULL)
         INITERROR;
-    struct module_state *st = GETSTATE(module);
+    st = GETSTATE(module);
 
     st->error = PyErr_NewException("lz4.Error", NULL, NULL);
     if (st->error == NULL) {

--- a/src/python-lz4.h
+++ b/src/python-lz4.h
@@ -42,6 +42,16 @@ PyMODINIT_FUNC initlz4(void);
 
 #if defined(_WIN32) && defined(_MSC_VER)
 # define inline __inline
+# if _MSC_VER >= 1600
+#  include <stdint.h>
+# else /* _MSC_VER >= 1600 */
+   typedef signed char       int8_t;
+   typedef signed short      int16_t;
+   typedef signed int        int32_t;
+   typedef unsigned char     uint8_t;
+   typedef unsigned short    uint16_t;
+   typedef unsigned int      uint32_t;
+# endif /* _MSC_VER >= 1600 */
 #endif
 
 #if defined(__SUNPRO_C) || defined(__hpux) || defined(_AIX)


### PR DESCRIPTION
The VS C Compiler doesn't like defining variables on places other than
the top of the function and doesn't natively support stdint.h.
