### PR TITLE
gcc doesn't know -O# for # > 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ setup(
             'src/lz4.c',
             'src/lz4hc.c',
             'src/python-lz4.c'
-        ], extra_compile_args=["-O4"])
+            ],
+            extra_compile_args=["-O3"]
+        )
     ],
     setup_requires=["nose>=1.0"],
     test_suite = "nose.collector",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup, find_packages, Extension
 
-VERSION = (0, 6, 0)
+VERSION = (0, 6, 1)
 
 setup(
     name='lz4',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     test_suite = "nose.collector",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: BSD 3-Clause License',
+        'License :: OSI Approved :: BSD License',
         'Intended Audience :: Developers',
         'Programming Language :: C',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     test_suite = "nose.collector",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: BSD 3-Clause License',
         'Intended Audience :: Developers',
         'Programming Language :: C',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,13 @@ setup(
     ],
     setup_requires=["nose>=1.0"],
     test_suite = "nose.collector",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Programming Language :: C',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
+    ],
 )


### PR DESCRIPTION
http://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

In addition the lines around the extra_compile_args are realligned
to ease the patching in downstream projects.

Signed-off-by: Justin Lecher jlec@gentoo.org
