### PR TITLE
Export VERSION and LZ4_VERSION. Close #19

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,11 @@
 from setuptools import setup, find_packages, Extension
 
 VERSION = (0, 7, 0)
+VERSION_STR = ".".join([str(x) for x in VERSION]),
 
 setup(
     name='lz4',
-    version=".".join([str(x) for x in VERSION]),
+    version=VERSION_STR,
     description="LZ4 Bindings for Python",
     long_description=open('README.rst', 'r').read(),
     author='Steeve Morin',
@@ -26,6 +27,7 @@ setup(
             "-Wall",
             "-W",
             "-Wundef",
+            "-DVERSION=\"%s\"" % VERSION_STR,
             "-DLZ4_VERSION=\"r119\"",
         ])
     ],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages, Extension
 
 VERSION = (0, 7, 0)
-VERSION_STR = ".".join([str(x) for x in VERSION]),
+VERSION_STR = ".".join([str(x) for x in VERSION])
 
 setup(
     name='lz4',

--- a/src/python-lz4.c
+++ b/src/python-lz4.c
@@ -202,6 +202,9 @@ void initlz4(void)
         INITERROR;
     }
 
+    PyModule_AddStringConstant(module, "VERSION", VERSION);
+    PyModule_AddStringConstant(module, "LZ4_VERSION", LZ4_VERSION);
+
 #if PY_MAJOR_VERSION >= 3
     return module;
 #endif


### PR DESCRIPTION
Export VERSION and LZ4_VERSION, so that users can known which version of python-lz4 they are using.

``` python
>>> import lz4
>>> lz4.VERSION
'0.7.0'
>>> lz4.LZ4_VERSION
'r119'
```
