### PR TITLE
Only setup_require nose if test command is actually run.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-
+import sys
 from setuptools import setup, find_packages, Extension
 
 VERSION = (0, 7, 0)
@@ -31,7 +31,7 @@ setup(
             "-DLZ4_VERSION=\"r119\"",
         ])
     ],
-    setup_requires=["nose>=1.0"],
+    setup_requires=["nose>=1.0"] if 'test' in sys.argv else [],
     test_suite = "nose.collector",
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
As seen here: https://bitbucket.org/jaraco/jaraco.test/src/ef8efc762486028bf46d09861799e70414a48d01/setup.py?at=default#cl-13

Replaces #34.
